### PR TITLE
Kintone::KintoneError発生時のメッセージにerrorsの内容も出力する

### DIFF
--- a/lib/kintone/kintone_error.rb
+++ b/lib/kintone/kintone_error.rb
@@ -7,6 +7,8 @@ class Kintone::KintoneError < StandardError
     @code = messages['code']
     @errors = messages['errors']
     @http_status = http_status
-    super(format('%s [%s] %s(%s)', @http_status, @code, @message_text, @id))
+    message_body = format('%s [%s] %s(%s)', @http_status, @code, @message_text, @id)
+    message_body = format("%s\n%s", message_body, JSON.pretty_generate(@errors)) if @errors.present?
+    super(message_body)
   end
 end

--- a/spec/kintone/kintone_error_spec.rb
+++ b/spec/kintone/kintone_error_spec.rb
@@ -62,7 +62,7 @@ describe Kintone::KintoneError do
 
       let(:http_status) { 400 }
 
-      it { is_expected.to eq '400 [CB_VA01] 入力内容が正しくありません。(1505999166-836316825)' }
+      it { is_expected.to start_with "400 [CB_VA01] 入力内容が正しくありません。(1505999166-836316825)\n" }
 
       describe '#message_text' do
         subject { target.message_text }


### PR DESCRIPTION
## Kintone::KintoneError発生時のエラーメッセージ例
```
Kintone::KintoneError: 400 [CB_VA01] 入力内容が正しくありません。(xxxxxxxxxxxxxxxxxxxx)
```

## 希望
```
Kintone::KintoneError: 400 [CB_VA01] 入力内容が正しくありません。(xxxxxxxxxxxxxxxxxxxx){"properties[テスト（値１）].code"=>{"messages"=>["フィールドコードに使用できない文字が含まれています。"]}, "properties[テスト（値２）].code"=>{"messages"=>["フィールドコードに使用できない文字が含まれています。"]}}
```
上記の様に、errorsの内容も出力して欲しい
https://github.com/jue58/kintone/commit/95dafae1a54c7154615e3c62236a1c74a4dd3175